### PR TITLE
[story/TP-101038] update dm-sql-finders to 3.2 and dependencies to our gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gemspec
 SOURCE         = ENV.fetch('SOURCE', :git).to_sym
 REPO_POSTFIX   = (SOURCE == :path) ? '' : '.git'
 DATAMAPPER     = (SOURCE == :path) ? Pathname(__FILE__).dirname.parent : 'https://github.com/firespring'
-DM_VERSION     = '~> 1.3.0'.freeze
+DM_VERSION     = '~> 1.3'.freeze
 DO_VERSION     = '~> 0.11.0'.freeze
 DM_DO_ADAPTERS = %w(sqlite postgres mysql oracle sqlserver).freeze
 CURRENT_BRANCH = ENV.fetch('GIT_BRANCH', 'master')

--- a/dm-aggregates.gemspec
+++ b/dm-aggregates.gemspec
@@ -15,6 +15,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = DataMapper::Aggregates::VERSION
   gem.required_ruby_version = '>= 2.7.8'
-
-  gem.add_runtime_dependency('sbf-dm-core', '~> 1.3.0')
+  gem.add_runtime_dependency('sbf-dm-core', '~> 1.3')
 end

--- a/lib/dm-aggregates/adapters/dm-do-adapter.rb
+++ b/lib/dm-aggregates/adapters/dm-do-adapter.rb
@@ -60,13 +60,13 @@ module DataMapper
       end
 
       chainable do
-        def property_to_column_name(property, qualify)
+        def chainable_property_to_column_name(property, qualify)
           case property
           when DataMapper::Query::Operator
             aggregate_field_statement(property.operator, property.target, qualify)
 
           when Property, DataMapper::Query::Path
-            super
+            property_to_column_name(property, qualify)
 
           else
             raise ArgumentError, '+property+ must be a DataMapper::Query::Operator, a DataMapper::Property or a Query::Path, but was a ' \

--- a/lib/dm-aggregates/adapters/dm-do-adapter.rb
+++ b/lib/dm-aggregates/adapters/dm-do-adapter.rb
@@ -59,18 +59,22 @@ module DataMapper
         property.load(value)
       end
 
-      chainable do
-        def chainable_property_to_column_name(property, qualify)
+      def self.included(base)
+        base.prepend(PropertyToColumnName)
+      end
+
+      module PropertyToColumnName
+        def property_to_column_name(property, qualify)
           case property
           when DataMapper::Query::Operator
             aggregate_field_statement(property.operator, property.target, qualify)
 
           when Property, DataMapper::Query::Path
-            property_to_column_name(property, qualify)
+            super
 
           else
             raise ArgumentError, '+property+ must be a DataMapper::Query::Operator, a DataMapper::Property or a Query::Path, but was a ' \
-                                 "#{property.class} (#{property.inspect})"
+              "#{property.class} (#{property.inspect})"
           end
         end
       end

--- a/lib/dm-aggregates/version.rb
+++ b/lib/dm-aggregates/version.rb
@@ -1,5 +1,5 @@
 module DataMapper
   module Aggregates
-    VERSION = '1.3.0'.freeze
+    VERSION = '1.4.0'.freeze
   end
 end

--- a/lib/dm-aggregates/version.rb
+++ b/lib/dm-aggregates/version.rb
@@ -1,5 +1,5 @@
 module DataMapper
   module Aggregates
-    VERSION = '1.4.0'.freeze
+    VERSION = '1.5.0'.freeze
   end
 end


### PR DESCRIPTION
renamed the chainable method so it didn't get overwritten with new module inclusion and less strict version to publish gems less often